### PR TITLE
Author comparison

### DIFF
--- a/src/jacowvalidator/spms.py
+++ b/src/jacowvalidator/spms.py
@@ -68,12 +68,12 @@ def reference_csv_check(filename_minus_ext, title, authors):
             else:
                 if filename_minus_ext == row[paper_col]:
                     reference_title = RE_MULTI_SPACE.sub(' ', row[title_col].upper())
-                    title_match = title.upper() == reference_title
+                    title_match = title.upper().strip('*') == reference_title
                     report, authors_match = get_author_list_report(authors, row[authors_col])
                     return {
                         'title': {
                             'match': title_match,
-                            'docx': title.upper(),
+                            'docx': title,
                             'spms': reference_title
                         },
                         'author': {
@@ -130,7 +130,7 @@ def get_author_list_report(docx_text, spms_text):
     # create a copy of spms_list and docx_list so that we can remove items
     #  without mutating the originals:
     fixed_spms_list = insert_spaces_after_periods(spms_list)
-    fixed_docx_list = remove_asterisks(insert_spaces_after_periods(docx_list))
+    fixed_docx_list = remove_asterisks_from_str_list(insert_spaces_after_periods(docx_list))
     spms_authors_to_check = clone_list(fixed_spms_list)
     results = list()
     all_authors_match = True
@@ -167,7 +167,7 @@ def insert_spaces_after_periods(author_list_to_adjust):
     return new_list
 
 
-def remove_asterisks(author_list_to_clean):
+def remove_asterisks_from_str_list(author_list_to_clean):
     new_list = list()
     for author in author_list_to_clean:
         fixed_author = author.strip('*')

--- a/src/jacowvalidator/spms.py
+++ b/src/jacowvalidator/spms.py
@@ -81,8 +81,7 @@ def reference_csv_check(filename_minus_ext, title, authors):
                             'spms': row[authors_col],
                             'docx_list': get_author_list(authors),
                             'spms_list': get_author_list(row[authors_col]),
-                            'report': get_author_list_report(get_author_list(authors),
-                                                             get_author_list(row[authors_col]))
+                            'report': get_author_list_report(authors, row[authors_col])
                         }
                     }
 
@@ -107,7 +106,7 @@ def reference_csv_check(filename_minus_ext, title, authors):
             raise PaperNotFoundError("No matching paper found in the spms csv file")
 
 
-def get_author_list_report(docx_list, spms_list):
+def get_author_list_report(docx_text, spms_text):
     """Compares two lists of authors (one sourced from the uploaded docx file
     and one sourced from the corresponding paper's entry in the SPMS references
     csv file) and produces a dict array report of the
@@ -125,6 +124,8 @@ def get_author_list_report(docx_list, spms_list):
             },
         ]
     """
+    docx_list = get_author_list(docx_text)
+    spms_list = get_author_list(spms_text)
     # create a copy of spms_list and docx_list so that we can remove items
     #  without mutating the originals:
     fixed_spms_list = insert_spaces_after_periods(spms_list)
@@ -135,12 +136,12 @@ def get_author_list_report(docx_list, spms_list):
             results.append({'match': True, 'docx': author, 'spms': author})
             spms_authors_to_check.remove(author)
         else:
-            results.append({'match': False, 'docx': author, 'spms': ''})
+            results.append({'match': False, 'docx': author, 'spms': spms_text})
 
     # by now any authors remaining in the spms_authors_to_check list are ones
     # that had no matching author in the docx list:
     for author in spms_authors_to_check:
-        results.append({'match': False, 'docx': '', 'spms': author})
+        results.append({'match': False, 'docx': docx_text, 'spms': author})
 
     return results
 

--- a/src/jacowvalidator/templates/upload.html
+++ b/src/jacowvalidator/templates/upload.html
@@ -695,14 +695,10 @@
                 <tbody>
                 <tr><td>Title</td><td>{{ reference_csv_details['title']['match']|tick_cross }}</td>
                 <td>
-                {% if reference_csv_details['title']['match'] == False %}
                     {{ reference_csv_details['title']['docx'] }}
-                {% endif %}
                 </td>
                 <td>
-                {% if reference_csv_details['title']['match'] == False %}
                     {{ reference_csv_details['title']['spms'] }}
-                {% endif %}
                 </td>
                 </tr>
                 {% if reference_csv_details['author']['report']|length == 1 and reference_csv_details['author']['report'][0]['match'] == False %}


### PR DESCRIPTION
These add some requested behaviour changes to the manner in which authors are compared as well as how the results are displayed:

- ignore asterisks in both titles and author lists in the docx
- when an author doesn't have a match in a  corresponding list, print the list for visual comparison
- Corrects logic that previously failed to see an overall match for author lists unless both lists looked exactly the same (a valid overall match is still possible even if there is different ordering for example) 