### PR TITLE
Author refinements

### DIFF
--- a/src/jacowvalidator/docutils/authors.py
+++ b/src/jacowvalidator/docutils/authors.py
@@ -50,7 +50,9 @@ National Synchrotron Radiation Research Center, Hsinchu, Taiwan, R.O.C`
     """
     potential_authors = text.replace(' and ', ', ').split(', ')
     filtered_authors = list()
-    my_name_pattern = re.compile("(\\w\\.\\ ?)+([\\w]{2,}\\ ?)+")
+    my_name_pattern = re.compile("(-?\\w\\.\\ ?)+([\\w]{2,}\\ ?)+")
+    # the allowance of an optional hyphen preceding an initial is to satisfy a
+    # common pattern observed with the papers coming out of asia.
     for author in potential_authors:
         if my_name_pattern.match(author):   # match has an implied ^ at the start
             # which is ok for our purposes.

--- a/src/jacowvalidator/routes.py
+++ b/src/jacowvalidator/routes.py
@@ -217,7 +217,7 @@ def upload():
 
             if "URL_TO_JACOW_REFERENCES_CSV" in os.environ:
                 reference_csv_url = os.environ["URL_TO_JACOW_REFERENCES_CSV"]
-            author_text = ''.join([a['text'] for a in authors])
+            author_text = ''.join([a['text']+", " for a in authors])
             reference_csv_details = reference_csv_check(paper_name, title['text'], author_text)
             summary['SPMS'] = {
                 'title': 'Jacow References',

--- a/src/jacowvalidator/spms.py
+++ b/src/jacowvalidator/spms.py
@@ -129,8 +129,8 @@ def get_author_list_report(docx_text, spms_text):
     spms_list = get_author_list(spms_text)
     # create a copy of spms_list and docx_list so that we can remove items
     #  without mutating the originals:
-    fixed_spms_list = insert_spaces_after_periods(spms_list)
-    fixed_docx_list = remove_asterisks_from_str_list(insert_spaces_after_periods(docx_list))
+    fixed_spms_list = normalize_author_names(spms_list)
+    fixed_docx_list = normalize_author_names(docx_list)
     spms_authors_to_check = clone_list(fixed_spms_list)
     results = list()
     all_authors_match = True
@@ -167,9 +167,12 @@ def insert_spaces_after_periods(author_list_to_adjust):
     return new_list
 
 
-def remove_asterisks_from_str_list(author_list_to_clean):
+def normalize_author_names(author_list_to_clean):
     new_list = list()
-    for author in author_list_to_clean:
-        fixed_author = author.strip('*')
+    for author in insert_spaces_after_periods(author_list_to_clean):
+        # ignore asterisks when comparing:
+        fixed_author = author.replace('*', '')
+        # ignore hyphens when comparing:
+        fixed_author = fixed_author.replace('-', '')
         new_list.append(fixed_author)
     return new_list

--- a/src/jacowvalidator/spms.py
+++ b/src/jacowvalidator/spms.py
@@ -140,13 +140,13 @@ def get_author_list_report(docx_text, spms_text):
             spms_authors_to_check.remove(author)
         else:
             all_authors_match = False
-            results.append({'match': False, 'docx': author, 'spms': spms_text})
+            results.append({'match': False, 'docx': author, 'spms': ''})
 
     # by now any authors remaining in the spms_authors_to_check list are ones
     # that had no matching author in the docx list:
     for author in spms_authors_to_check:
         all_authors_match = False
-        results.append({'match': False, 'docx': docx_text, 'spms': author})
+        results.append({'match': False, 'docx': '', 'spms': author})
 
     return results, all_authors_match
 

--- a/src/jacowvalidator/spms.py
+++ b/src/jacowvalidator/spms.py
@@ -174,5 +174,5 @@ def normalize_author_names(author_list_to_clean):
         fixed_author = author.replace('*', '')
         # ignore hyphens when comparing:
         fixed_author = fixed_author.replace('-', '')
-        new_list.append(fixed_author)
+        new_list.append(fixed_author.strip())
     return new_list

--- a/src/jacowvalidator/templates/upload.html
+++ b/src/jacowvalidator/templates/upload.html
@@ -785,21 +785,18 @@
                     {{ reference_csv_details['title']['spms'] }}
                 </td>
                 </tr>
-                {% if reference_csv_details['author']['report']|length == 1 and reference_csv_details['author']['report'][0]['match'] == False %}
-                <tr><td>Author</td>
+                <tr><td>Author list</td>
                     <td>
-                        {{False|tick_cross }}
+                        {{reference_csv_details['author']['match']|tick_cross }}
                     </td>
-
                     <td>
                         {{ reference_csv_details['author']['docx'] }}
                     </td>
 
                     <td>
-                        {{ reference_csv_details['author']['report'][0]['spms'] }}
+                        {{ reference_csv_details['author']['spms'] }}
                     </td>
                 </tr>
-                {% else %}
                 {% for result in reference_csv_details['author']['report'] %}
                 <tr><td>{% if loop.index0 == 0 %}Author{% endif %}</td>
                     <td>
@@ -815,7 +812,6 @@
                     </td>
                 </tr>
                 {% endfor %}
-                {% endif %}
                 </tbody>
                 </table>
             </div>

--- a/src/jacowvalidator/templates/upload.html
+++ b/src/jacowvalidator/templates/upload.html
@@ -785,7 +785,7 @@
                     {{ reference_csv_details['title']['spms'] }}
                 </td>
                 </tr>
-                <tr><td>Author list</td>
+                <tr><td>Extracted Author List</td>
                     <td>
                         {{reference_csv_details['author']['match']|tick_cross }}
                     </td>


### PR DESCRIPTION
new developments in this PR include:
- prevent repetition of entire author list whenever a mismatch occurs
- print the entire author list from docx and spms at the top of the table regardless of overall match or not
- allow a preceding hyphen to an author initial (to satisfy majority of asian papers conventions)
- prevent the author extracting logic from wrapping between paragraphs (previous logic required a comma to separate names from other names and affiliations but some papers put affiliations on a new line without ending the previous line with a comma)