### PR TITLE
Add accented character transliteration to author comparison

### DIFF
--- a/src/jacowvalidator/docutils/authors.py
+++ b/src/jacowvalidator/docutils/authors.py
@@ -56,7 +56,7 @@ National Synchrotron Radiation Research Center, Hsinchu, Taiwan, R.O.C`
     """
     newline_fixed_text = text
     for newline_char in LINE_TERMINATOR_CHARS:
-        newline_fixed_text = newline_fixed_text.replace(newline_char, ', ')
+        newline_fixed_text = newline_fixed_text.replace(newline_char, ' , ')
     potential_authors = newline_fixed_text.replace(NON_BREAKING_SPACE, ' ').replace(' and ', ', ').split(', ')
     filtered_authors = list()
     my_name_pattern = re.compile("(-?\\w\\.\\ ?)+([\\w]{2,}\\ ?)+")


### PR DESCRIPTION
This will introduce the ability to compare authors where one author is written with non-ascii characters found in the set found at:
https://stackoverflow.com/questions/6837148/change-foreign-characters-to-their-normal-equivalent
and be able to make a match with the matching author name written with transliterated ascii characters as long as they match the mappings found in the above link.

This also fixes a minor bug whereby author names in a docx that were delimited by a newline instead of a comma were not properly parsed.